### PR TITLE
Feat/remove editor context canvas

### DIFF
--- a/apps/page-builder-demo/src/app/DocumenWidgetInline.tsx
+++ b/apps/page-builder-demo/src/app/DocumenWidgetInline.tsx
@@ -33,7 +33,21 @@ export const DocumentWidgetInline: React.FC<{
       }
     }
 
+    function handleMessageParentWindow(event: MessageEvent) {
+      if (event.data?.type?.includes("@easyblocks-editor")) {
+        editorIframeNode?.contentWindow?.postMessage(
+          {
+            type: event.data.type,
+            payload: event.data.payload,
+          },
+          "*"
+        );
+      }
+    }
+
     editorIframeNode?.contentWindow?.addEventListener("message", handleMessage);
+
+    window.addEventListener("message", handleMessageParentWindow);
 
     return () => {
       editorIframeNode?.contentWindow?.removeEventListener(

--- a/packages/core/src/_internals.ts
+++ b/packages/core/src/_internals.ts
@@ -27,6 +27,7 @@ export type {
   EditorContextType,
   InternalComponentDefinition,
   InternalRenderableComponentDefinition,
+  EditorActions,
 } from "./compiler/types";
 export {
   EasyblocksMetadataProvider,
@@ -39,3 +40,7 @@ export {
 } from "./components/ComponentBuilder/ComponentBuilder";
 export { createTestCompilationContext, createFormMock } from "./testUtils";
 export * from "./compiler/builtins/$richText/builders";
+export {
+  EasyblocksCanvasProvider,
+  useEasyblocksCanvasContext,
+} from "./components/EasyblocksCanvasProvider";

--- a/packages/core/src/compiler/builtins/$richText/$richText.editor.tsx
+++ b/packages/core/src/compiler/builtins/$richText/$richText.editor.tsx
@@ -71,7 +71,7 @@ interface RichTextProps extends InternalNoCodeComponentProps {
 }
 
 function RichTextEditor(props: RichTextProps) {
-  const { editorContext } = (window.parent as any).editorWindowAPI;
+  // const { editorContext } = (window.parent as any).editorWindowAPI;
   const { formValues, locales, locale, focussedField, definitions } =
     useEasyblocksCanvasContext();
 
@@ -754,7 +754,10 @@ function RichTextEditor(props: RichTextProps) {
   function handleEditableCopy(event: React.ClipboardEvent) {
     const selectedRichTextComponentConfig = getRichTextComponentConfigFragment(
       richTextConfig,
-      editorContext
+      focussedField,
+      locale,
+      formValues,
+      definitions
     );
 
     event.clipboardData.setData(
@@ -775,8 +778,9 @@ function RichTextEditor(props: RichTextProps) {
       event.preventDefault();
 
       const nextSlateValue = convertRichTextElementsToEditorValue(
-        duplicateConfig(selectedRichTextComponentConfig, editorContext)
-          .elements[locale]
+        duplicateConfig(selectedRichTextComponentConfig, definitions).elements[
+          locale
+        ]
       );
 
       const temporaryEditor = createTemporaryEditor(editor);

--- a/packages/core/src/compiler/builtins/$richText/utils/getEditorSelectionFromFocusedFields.ts
+++ b/packages/core/src/compiler/builtins/$richText/utils/getEditorSelectionFromFocusedFields.ts
@@ -4,7 +4,7 @@ import { parseFocusedRichTextPartConfigPath } from "./parseRichTextPartConfigPat
 
 function getEditorSelectionFromFocusedFields(
   focusedFields: Array<string>,
-  form: any
+  formValues: any
 ): Selection {
   try {
     const anchorFocusedField = focusedFields[0];
@@ -26,7 +26,7 @@ function getEditorSelectionFromFocusedFields(
       focus: {
         offset: parsedFocusedField.range
           ? parsedFocusedField.range[1]
-          : dotNotationGet(form.values, focusFocusedField).value.length,
+          : dotNotationGet(formValues, focusFocusedField).value.length,
         path: parsedFocusedField.path,
       },
     };

--- a/packages/core/src/compiler/builtins/$richText/utils/getRichTextComponentConfigFragment.ts
+++ b/packages/core/src/compiler/builtins/$richText/utils/getRichTextComponentConfigFragment.ts
@@ -11,34 +11,35 @@ import { stripRichTextPartSelection } from "./stripRichTextTextPartSelection";
 
 function getRichTextComponentConfigFragment(
   sourceRichTextComponentConfig: RichTextComponentConfig,
-  editorContext: EditorContextType
+  focussedField: EditorContextType["focussedField"],
+  locale: EditorContextType["contextParams"]["locale"],
+  formValues: EditorContextType["form"]["values"],
+  definitions: EditorContextType["definitions"]
 ): RichTextComponentConfig & {
   _itemProps?: Record<string, unknown>;
 } {
-  const { focussedField, form, contextParams } = editorContext;
-
   const newRichTextComponentConfig: RichTextComponentConfig = {
     ...sourceRichTextComponentConfig,
     elements: {
-      [contextParams.locale]: [],
+      [locale]: [],
     },
   };
 
   focussedField.forEach((focusedField) => {
     const textPartConfig: RichTextPartComponentConfig = get(
-      form.values,
+      formValues,
       stripRichTextPartSelection(focusedField)
     );
 
     const { path, range } = parseFocusedRichTextPartConfigPath(focusedField);
 
-    const newTextPartConfig = duplicateConfig(textPartConfig, editorContext);
+    const newTextPartConfig = duplicateConfig(textPartConfig, definitions);
 
     if (range) {
       newTextPartConfig.value = textPartConfig.value.slice(...range);
     }
 
-    let lastParentConfigPath = `elements.${contextParams.locale}`;
+    let lastParentConfigPath = `elements.${locale}`;
 
     path.slice(0, -1).forEach((pathIndex, index) => {
       let currentConfigPath = lastParentConfigPath;

--- a/packages/core/src/compiler/builtins/$text/$text.editor.tsx
+++ b/packages/core/src/compiler/builtins/$text/$text.editor.tsx
@@ -3,6 +3,7 @@ import { dotNotationGet } from "@easyblocks/utils";
 import React, { ReactElement } from "react";
 import { InternalNoCodeComponentProps } from "../../../components/ComponentBuilder/ComponentBuilder";
 import { InlineTextarea } from "./InlineTextarea";
+import { useEasyblocksCanvasContext } from "../../../_internals";
 
 type TextProps = {
   value: string | undefined;
@@ -16,9 +17,10 @@ function TextEditor(props: TextProps) {
     __easyblocks: { path, runtime },
   } = props;
 
-  const { form } = (window.parent as any).editorWindowAPI.editorContext;
+  const { formValues } = useEasyblocksCanvasContext();
+
   const valuePath = `${path}.value`;
-  const configValue = dotNotationGet(form.values, valuePath);
+  const configValue = dotNotationGet(formValues, valuePath);
   const isLocalTextReference = configValue.id?.startsWith("local.");
 
   return (

--- a/packages/core/src/compiler/builtins/$text/InlineTextarea.tsx
+++ b/packages/core/src/compiler/builtins/$text/InlineTextarea.tsx
@@ -3,6 +3,7 @@ import React, { ElementRef, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import TextareaAutosize from "react-textarea-autosize";
 import { useTextValue } from "../useTextValue";
+import { useEasyblocksCanvasContext } from "../../../_internals";
 
 interface InlineTextProps {
   path: string;
@@ -17,19 +18,21 @@ export function InlineTextarea({
 }: InlineTextProps) {
   const [isEnabled, setIsEnabled] = useState(false);
   const textAreaRef = useRef<ElementRef<"textarea">>(null);
+  const { formValues, locale, locales } = useEasyblocksCanvasContext();
 
-  const {
-    form,
-    contextParams: { locale },
-    locales,
-  } = (window.parent as any).editorWindowAPI.editorContext;
   const valuePath = `${path}.value`;
-  const value = dotNotationGet(form.values, valuePath);
+  const value = dotNotationGet(formValues, valuePath);
 
   const inputProps = useTextValue(
     value,
     (val: string | null) => {
-      form.change(valuePath, val);
+      window.parent.postMessage({
+        type: "@easyblocks-editor/form-change",
+        payload: {
+          key: valuePath,
+          value: val,
+        },
+      });
     },
     locale,
     locales,

--- a/packages/core/src/compiler/duplicateConfig.ts
+++ b/packages/core/src/compiler/duplicateConfig.ts
@@ -2,11 +2,11 @@ import { deepClone, uniqueId } from "@easyblocks/utils";
 import { NoCodeComponentEntry } from "../types";
 import { configTraverse } from "./configTraverse";
 import { traverseComponents } from "./traverseComponents";
-import { CompilationContextType } from "./types";
+import { AnyContextWithDefinitions } from "./types";
 
 export function duplicateConfig<
   ConfigType extends NoCodeComponentEntry = NoCodeComponentEntry
->(inputConfig: ConfigType, compilationContext: CompilationContextType) {
+>(inputConfig: ConfigType, compilationContext: AnyContextWithDefinitions) {
   // deep copy first
   const config = deepClone(inputConfig);
 

--- a/packages/core/src/compiler/traverseComponents.ts
+++ b/packages/core/src/compiler/traverseComponents.ts
@@ -1,7 +1,7 @@
 import { NoCodeComponentEntry } from "../types";
 import { findComponentDefinition } from "./findComponentDefinition";
 import { isSchemaPropComponent } from "./schema";
-import { CompilationContextType } from "./types";
+import { AnyContextWithDefinitions } from "./types";
 
 type TraverseComponentsCallback = (arg: {
   path: string;
@@ -12,7 +12,7 @@ type TraverseComponentsCallback = (arg: {
  */
 function traverseComponents(
   config: NoCodeComponentEntry,
-  context: CompilationContextType,
+  context: AnyContextWithDefinitions,
   callback: TraverseComponentsCallback
 ): void {
   traverseComponentsInternal(config, context, callback, "");
@@ -20,7 +20,7 @@ function traverseComponents(
 
 function traverseComponentsArray(
   array: NoCodeComponentEntry[],
-  context: CompilationContextType,
+  context: AnyContextWithDefinitions,
   callback: TraverseComponentsCallback,
   path: string
 ) {
@@ -31,7 +31,7 @@ function traverseComponentsArray(
 
 function traverseComponentsInternal(
   componentConfig: NoCodeComponentEntry,
-  context: CompilationContextType,
+  context: AnyContextWithDefinitions,
   callback: TraverseComponentsCallback,
   path: string
 ) {

--- a/packages/core/src/compiler/types.ts
+++ b/packages/core/src/compiler/types.ts
@@ -168,3 +168,7 @@ export type EditorContextType = CompilationContextType & {
   actions: EditorActions;
   templates?: Template[];
 };
+
+export type AnyContextWithDefinitions = {
+  definitions: InternalComponentDefinitions;
+};

--- a/packages/core/src/compiler/types.ts
+++ b/packages/core/src/compiler/types.ts
@@ -134,7 +134,7 @@ export type InternalComponentDefinitions = {
   components: InternalRenderableComponentDefinition<string, any, any>[];
 };
 
-type EditorActions = {
+export type EditorActions = {
   notify: (message: string) => void;
   openComponentPicker: (config: {
     path: string;

--- a/packages/core/src/components/EasyblocksCanvasProvider.tsx
+++ b/packages/core/src/components/EasyblocksCanvasProvider.tsx
@@ -18,11 +18,11 @@ type EasyblocksCanvasState = {
   externalData: FetchOutputResources | null;
   formValues: EditorContextType["form"]["values"] | null;
   definitions: EditorContextType["definitions"] | null;
-  locale: EditorContextType["contextParams"]["locale"] | null;
-  locales: EditorContextType["locales"] | null;
+  locale: EditorContextType["contextParams"]["locale"];
+  locales: EditorContextType["locales"];
   isEditing: EditorContextType["isEditing"];
   devices: EditorContextType["devices"] | null;
-  focussedField: EditorContextType["focussedField"] | null;
+  focussedField: EditorContextType["focussedField"];
 };
 
 const initialState: EasyblocksCanvasState = {
@@ -31,11 +31,11 @@ const initialState: EasyblocksCanvasState = {
   externalData: null,
   formValues: null,
   definitions: null,
-  locale: null,
-  locales: null,
+  locale: "",
+  locales: [],
   isEditing: false,
   devices: null,
-  focussedField: null,
+  focussedField: [],
 };
 
 const EasyblocksCanvasContext = createContext<

--- a/packages/core/src/components/EasyblocksCanvasProvider.tsx
+++ b/packages/core/src/components/EasyblocksCanvasProvider.tsx
@@ -1,0 +1,84 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useState,
+  useEffect,
+} from "react";
+import { EditorContextType } from "../_internals";
+import {
+  CompilationMetadata,
+  CompiledShopstoryComponentConfig,
+  FetchOutputResources,
+} from "../types";
+
+type EasyblocksCanvasState = {
+  meta: CompilationMetadata | null;
+  compiled: CompiledShopstoryComponentConfig | null;
+  externalData: FetchOutputResources | null;
+  formValues: EditorContextType["form"]["values"] | null;
+  definitions: EditorContextType["definitions"] | null;
+  locale: EditorContextType["contextParams"]["locale"] | null;
+  locales: EditorContextType["locales"] | null;
+  isEditing: EditorContextType["isEditing"];
+  devices: EditorContextType["devices"] | null;
+  focussedField: EditorContextType["focussedField"] | null;
+};
+
+const initialState: EasyblocksCanvasState = {
+  meta: null,
+  compiled: null,
+  externalData: null,
+  formValues: null,
+  definitions: null,
+  locale: null,
+  locales: null,
+  isEditing: false,
+  devices: null,
+  focussedField: null,
+};
+
+const EasyblocksCanvasContext = createContext<
+  EasyblocksCanvasState | undefined
+>(undefined);
+
+type EasyblocksCanvasProviderProps = {
+  children: ReactNode;
+};
+
+const EasyblocksCanvasProvider: React.FC<EasyblocksCanvasProviderProps> = ({
+  children,
+}) => {
+  const [state, setState] = useState<EasyblocksCanvasState>(initialState);
+
+  useEffect(() => {
+    const handler = (event: any) => {
+      if (event.data.type === "@easyblocks/canvas-data") {
+        const data = JSON.parse(event.data.data);
+        setState((prevState) => ({ ...prevState, ...data }));
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => {
+      window.removeEventListener("message", handler);
+    };
+  }, []);
+
+  return (
+    <EasyblocksCanvasContext.Provider value={state}>
+      {children}
+    </EasyblocksCanvasContext.Provider>
+  );
+};
+
+const useEasyblocksCanvasContext = () => {
+  const context = useContext(EasyblocksCanvasContext);
+  if (!context) {
+    throw new Error(
+      "useEasyblocksCanvasContext must be used within a EasyblocksCanvasProvider"
+    );
+  }
+  return context;
+};
+
+export { EasyblocksCanvasProvider, useEasyblocksCanvasContext };

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -136,6 +136,18 @@ type UndoEvent = MessageEvent<
     }
   >
 >;
+
+type FormChangeEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/form-change",
+    {
+      key: string;
+      value: any;
+      focussedField?: Array<string> | string;
+    }
+  >
+>;
+
 type RedoEvent = MessageEvent<
   EasyblocksEditorEventData<
     "@easyblocks-editor/redo",
@@ -193,4 +205,5 @@ export type {
   UndoEvent,
   RedoEvent,
   SetFocussedFieldEvent,
+  FormChangeEvent,
 };

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,5 +1,5 @@
 import { serialize } from "@easyblocks/utils";
-import { NoCodeComponentEntry, SchemaProp } from "./types";
+import { ConfigDevices, NoCodeComponentEntry, SchemaProp } from "./types";
 import { Component$$$SchemaProp } from "./compiler/schema";
 
 type EasyblocksEditorEventData<
@@ -119,6 +119,50 @@ type ItemMovedEvent = MessageEvent<
   >
 >;
 
+type ChangeResponsiveEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/change-responsive",
+    {
+      device: keyof ConfigDevices;
+    }
+  >
+>;
+
+type UndoEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/undo",
+    {
+      type: "@easyblocks-editor/undo";
+    }
+  >
+>;
+type RedoEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/redo",
+    {
+      type: "@easyblocks-editor/redo";
+    }
+  >
+>;
+
+type SetFocussedFieldEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/focus-field",
+    {
+      target: Array<string> | string;
+    }
+  >
+>;
+
+type SelectComponentEvent = MessageEvent<
+  EasyblocksEditorEventData<
+    "@easyblocks-editor/select-component",
+    {
+      target: string;
+    }
+  >
+>;
+
 function itemMoved(
   payload: InferShopstoryEditorEventData<ItemMovedEvent>["payload"]
 ): InferShopstoryEditorEventData<ItemMovedEvent> {
@@ -145,4 +189,8 @@ export type {
   RichTextChangedEvent,
   SelectionFramePositionChangedEvent,
   EasyblocksEditorEventData,
+  ChangeResponsiveEvent,
+  UndoEvent,
+  RedoEvent,
+  SetFocussedFieldEvent,
 };

--- a/packages/editor/src/CanvasRoot/CanvasRoot.tsx
+++ b/packages/editor/src/CanvasRoot/CanvasRoot.tsx
@@ -1,24 +1,31 @@
 import React, { ReactNode } from "react";
 import { useEditorGlobalKeyboardShortcuts } from "../useEditorGlobalKeyboardShortcuts";
+import { useEasyblocksCanvasContext } from "@easyblocks/core/_internals";
 
 type CanvasRootProps = {
   children: ReactNode;
 };
 
 function CanvasRoot(props: CanvasRootProps) {
-  const { editorContext } = window.parent.editorWindowAPI;
+  // const { editorContext } = window.parent.editorWindowAPI;
+  const { isEditing } = useEasyblocksCanvasContext();
 
-  useEditorGlobalKeyboardShortcuts(editorContext);
+  // useEditorGlobalKeyboardShortcuts({editorContext});
 
   return (
     <div
       onClick={() => {
-        if (editorContext.isEditing) {
-          editorContext.setFocussedField([]);
+        if (isEditing) {
+          window.parent.postMessage({
+            type: "@easyblocks-editor/focus-field",
+            payload: {
+              target: [],
+            },
+          });
         }
       }}
     >
-      {editorContext.isEditing && (
+      {isEditing && (
         <div style={{ minHeight: "100vh" }}>
           <style
             dangerouslySetInnerHTML={{
@@ -28,7 +35,7 @@ function CanvasRoot(props: CanvasRootProps) {
           {props.children}
         </div>
       )}
-      {!editorContext.isEditing && props.children}
+      {!isEditing && props.children}
     </div>
   );
 }

--- a/packages/editor/src/CanvasRoot/CanvasRoot.tsx
+++ b/packages/editor/src/CanvasRoot/CanvasRoot.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import { useEditorGlobalKeyboardShortcuts } from "../useEditorGlobalKeyboardShortcuts";
 import { useEasyblocksCanvasContext } from "@easyblocks/core/_internals";
 
 type CanvasRootProps = {
@@ -7,10 +6,7 @@ type CanvasRootProps = {
 };
 
 function CanvasRoot(props: CanvasRootProps) {
-  // const { editorContext } = window.parent.editorWindowAPI;
   const { isEditing } = useEasyblocksCanvasContext();
-
-  // useEditorGlobalKeyboardShortcuts({editorContext});
 
   return (
     <div

--- a/packages/editor/src/EasyblocksEditor.tsx
+++ b/packages/editor/src/EasyblocksEditor.tsx
@@ -38,12 +38,10 @@ export function EasyblocksEditor(props: EasyblocksEditorProps) {
         if (window.parent !== window.self && window.parent.isShopstoryEditor) {
           setSelectedWindowToChild();
         } else {
-          // setSelectedWindowToParent();
-          setSelectedWindowToChild();
+          setSelectedWindowToParent();
         }
       } catch (error) {
-        // setSelectedWindowToParent();
-        setSelectedWindowToChild();
+        setSelectedWindowToParent();
       }
     }
   }, []);

--- a/packages/editor/src/EasyblocksEditor.tsx
+++ b/packages/editor/src/EasyblocksEditor.tsx
@@ -5,6 +5,7 @@ import { EasyblocksCanvas } from "./EditorChildWindow";
 import { PreviewRenderer } from "./PreviewRenderer";
 import { addDebugToEditorProps } from "./debug/addDebugToEditorProps";
 import { parseQueryParams } from "./parseQueryParams";
+import { EasyblocksCanvasProvider } from "@easyblocks/core/_internals";
 
 export function EasyblocksEditor(props: EasyblocksEditorProps) {
   const [selectedWindow, setSelectedWindow] = useState<
@@ -66,7 +67,9 @@ export function EasyblocksEditor(props: EasyblocksEditorProps) {
       )}
 
       {selectedWindow === "child" && (
-        <EasyblocksCanvas components={props.components} />
+        <EasyblocksCanvasProvider>
+          <EasyblocksCanvas components={props.components} />
+        </EasyblocksCanvasProvider>
       )}
 
       {selectedWindow === "preview" && <PreviewRenderer {...props} />}

--- a/packages/editor/src/EasyblocksEditor.tsx
+++ b/packages/editor/src/EasyblocksEditor.tsx
@@ -38,10 +38,12 @@ export function EasyblocksEditor(props: EasyblocksEditorProps) {
         if (window.parent !== window.self && window.parent.isShopstoryEditor) {
           setSelectedWindowToChild();
         } else {
-          setSelectedWindowToParent();
+          // setSelectedWindowToParent();
+          setSelectedWindowToChild();
         }
       } catch (error) {
-        setSelectedWindowToParent();
+        // setSelectedWindowToParent();
+        setSelectedWindowToChild();
       }
     }
   }, []);

--- a/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
+++ b/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
@@ -46,6 +46,10 @@ export function BlocksControls({
 }: BlocksControlsProps) {
   const { focussedField, formValues } = useEasyblocksCanvasContext();
 
+  if (!focussedField) {
+    return;
+  }
+
   const meta = useEasyblocksMetadata();
   const dndContext = useDndContext();
 
@@ -166,6 +170,10 @@ export function BlocksControls({
     const isMultipleSelection = event.shiftKey;
 
     function getNextFocusedField() {
+      if (!focussedField) {
+        return;
+      }
+
       if (isMultipleSelection) {
         if (focussedField.includes(path)) {
           const result = focussedField.filter(

--- a/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
+++ b/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
@@ -10,7 +10,11 @@ import {
   ComponentCollectionSchemaProp,
   SerializedRenderableComponentDefinition,
 } from "@easyblocks/core";
-import { parsePath, useEasyblocksMetadata } from "@easyblocks/core/_internals";
+import {
+  parsePath,
+  useEasyblocksCanvasContext,
+  useEasyblocksMetadata,
+} from "@easyblocks/core/_internals";
 import { Colors } from "@easyblocks/design-system";
 import { toArray } from "@easyblocks/utils";
 import React, { Fragment } from "react";
@@ -40,8 +44,7 @@ export function BlocksControls({
   index,
   length,
 }: BlocksControlsProps) {
-  const { focussedField, setFocussedField, form } =
-    window.parent.editorWindowAPI.editorContext;
+  const { focussedField, formValues } = useEasyblocksCanvasContext();
 
   const meta = useEasyblocksMetadata();
   const dndContext = useDndContext();
@@ -61,7 +64,7 @@ export function BlocksControls({
     focusedField.startsWith(path)
   );
 
-  const entryPathParseResult = parsePath(path, form);
+  const entryPathParseResult = parsePath(path, { values: formValues });
   const entryComponentDefinition = meta.vars.definitions.components.find(
     (c) => c.id === entryPathParseResult.parent!.templateId
   );
@@ -87,7 +90,7 @@ export function BlocksControls({
   });
 
   const draggedEntryPathParseResult = dndContext.active
-    ? parsePath(dndContext.active.data.current!.path, form)
+    ? parsePath(dndContext.active.data.current!.path, { values: formValues })
     : null;
 
   const draggedComponentDefinition = draggedEntryPathParseResult
@@ -184,7 +187,12 @@ export function BlocksControls({
 
     const nextFocusedField = getNextFocusedField();
 
-    setFocussedField(nextFocusedField);
+    window.parent.postMessage({
+      type: "@easyblocks-editor/focus-field",
+      payload: {
+        target: nextFocusedField,
+      },
+    });
 
     if (isMultipleSelection) {
       document.getSelection()?.removeAllRanges();

--- a/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
+++ b/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
@@ -1,5 +1,8 @@
 import type { useSortable } from "@dnd-kit/sortable";
-import { selectionFramePositionChanged } from "@easyblocks/core/_internals";
+import {
+  selectionFramePositionChanged,
+  useEasyblocksCanvasContext,
+} from "@easyblocks/core/_internals";
 import { Colors } from "@easyblocks/design-system";
 import React, { MouseEvent, ReactNode, useEffect, useState } from "react";
 
@@ -107,6 +110,8 @@ function SelectionFrameController({
     },
   });
 
+  const { focussedField } = useEasyblocksCanvasContext();
+
   useEffect(() => {
     return () => {
       // If the the node of active element is not in the DOM anymore we want to deselect it to prevent showing
@@ -115,9 +120,14 @@ function SelectionFrameController({
         isActive &&
         node &&
         !window.document.contains(node) &&
-        path === window.parent.editorWindowAPI.editorContext.focussedField[0]
+        path === focussedField[0]
       ) {
-        window.parent.editorWindowAPI.editorContext.setFocussedField([]);
+        window.parent.postMessage({
+          type: "@easyblocks-editor/focus-field",
+          payload: {
+            target: [],
+          },
+        });
       }
     };
   });
@@ -125,7 +135,10 @@ function SelectionFrameController({
   React.useEffect(() => {
     const onWindowMessage = (event: MessageEvent) => {
       if (event.data.type === "@easyblocks-editor/focus-field") {
-        if (event.data.payload.target === path) {
+        if (
+          event.data.payload.target === path &&
+          event.data.payload.scrollIntoView
+        ) {
           node?.scrollIntoView({
             behavior: "smooth",
           });

--- a/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
+++ b/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
@@ -114,6 +114,9 @@ function SelectionFrameController({
 
   useEffect(() => {
     return () => {
+      if (!focussedField) {
+        return;
+      }
       // If the the node of active element is not in the DOM anymore we want to deselect it to prevent showing
       // add buttons on the not existing element.
       if (

--- a/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
+++ b/packages/editor/src/EditableComponentBuilder/SelectionFrameController.tsx
@@ -122,6 +122,22 @@ function SelectionFrameController({
     };
   });
 
+  React.useEffect(() => {
+    const onWindowMessage = (event: MessageEvent) => {
+      if (event.data.type === "@easyblocks-editor/focus-field") {
+        if (event.data.payload.target === path) {
+          node?.scrollIntoView({
+            behavior: "smooth",
+          });
+        }
+      }
+    };
+    window.parent.addEventListener("message", onWindowMessage);
+    return () => {
+      window.parent.removeEventListener("message", onWindowMessage);
+    };
+  });
+
   return (
     <div
       data-active={isActive}

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -1006,11 +1006,11 @@ const EditorContent = ({
     return () => window.removeEventListener("message", handleEditorEvents);
   }, []);
 
-  const sendCanvasData = () => {
-    const shopstoryCanvasIframe = window.document.getElementById(
-      "shopstory-canvas"
-    ) as HTMLIFrameElement | undefined;
+  const shopstoryCanvasIframe = window.document.getElementById(
+    "shopstory-canvas"
+  ) as HTMLIFrameElement | undefined;
 
+  const sendCanvasData = () => {
     shopstoryCanvasIframe?.contentWindow?.postMessage(
       {
         type: "@easyblocks/canvas-data",
@@ -1033,7 +1033,7 @@ const EditorContent = ({
 
   const [isDataSaverOverlayOpen, setDataSaverOverlayOpen] = useState(false);
 
-  useEditorGlobalKeyboardShortcuts(editorContext);
+  useEditorGlobalKeyboardShortcuts(editorContext, shopstoryCanvasIframe);
 
   const { saveNow } = useDataSaver(initialDocument, editorContext);
 

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -24,10 +24,14 @@ import {
   validate,
 } from "@easyblocks/core";
 import {
+  ChangeResponsiveEvent,
   CompilationContextType,
   ComponentPickerOpenedEvent,
   ItemInsertedEvent,
   ItemMovedEvent,
+  RedoEvent,
+  SetFocussedFieldEvent,
+  UndoEvent,
   componentPickerClosed,
   duplicateConfig,
   findComponentDefinitionById,
@@ -881,8 +885,31 @@ const EditorContent = ({
 
   useEffect(() => {
     function handleEditorEvents(
-      event: ComponentPickerOpenedEvent | ItemInsertedEvent | ItemMovedEvent
+      event:
+        | ComponentPickerOpenedEvent
+        | ItemInsertedEvent
+        | ItemMovedEvent
+        | ChangeResponsiveEvent
+        | SetFocussedFieldEvent
+        | UndoEvent
+        | RedoEvent
     ) {
+      if (event.data.type === "@easyblocks-editor/focus-field") {
+        handleSetFocussedField(event.data.payload.target);
+      }
+
+      if (event.data.type === "@easyblocks-editor/change-responsive") {
+        setCurrentViewport(event.data.payload.device);
+      }
+
+      if (event.data.type === "@easyblocks-editor/undo") {
+        undo();
+      }
+
+      if (event.data.type === "@easyblocks-editor/redo") {
+        redo();
+      }
+
       if (event.data.type === "@easyblocks-editor/component-picker-opened") {
         actions
           .openComponentPicker({ path: event.data.payload.path })

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -27,6 +27,7 @@ import {
   ChangeResponsiveEvent,
   CompilationContextType,
   ComponentPickerOpenedEvent,
+  FormChangeEvent,
   ItemInsertedEvent,
   ItemMovedEvent,
   RedoEvent,
@@ -894,7 +895,24 @@ const EditorContent = ({
         | SetFocussedFieldEvent
         | UndoEvent
         | RedoEvent
+        | FormChangeEvent
     ) {
+      if (event.data.type === "@easyblocks-editor/form-change") {
+        if (event.data.payload.focussedField) {
+          actions.runChange(() => {
+            if (
+              event.data.type === "@easyblocks-editor/form-change" &&
+              Array.isArray(event.data.payload.focussedField)
+            ) {
+              form.change(event.data.payload.key, event.data.payload.value);
+              return event.data.payload.focussedField;
+            }
+          });
+        } else {
+          form.change(event.data.payload.key, event.data.payload.value);
+        }
+      }
+
       if (event.data.type === "@easyblocks-editor/focus-field") {
         handleSetFocussedField(event.data.payload.target);
       }

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -873,7 +873,6 @@ const EditorContent = ({
   }, []);
 
   useEffect(() => {
-    sendCanvasData();
     if (window.editorWindowAPI.onUpdate) {
       window.editorWindowAPI.onUpdate();
     }
@@ -1124,6 +1123,11 @@ const EditorContent = ({
                   height={iframeSize.height}
                   transform={iframeSize.transform}
                   containerRef={iframeContainerRef}
+                  onIframeLoaded={() => {
+                    setTimeout(() => {
+                      sendCanvasData();
+                    }, 10);
+                  }}
                 />
                 {isEditing && (
                   <SelectionFrame

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -872,6 +872,7 @@ const EditorContent = ({
   }, []);
 
   useEffect(() => {
+    sendCanvasData();
     if (window.editorWindowAPI.onUpdate) {
       window.editorWindowAPI.onUpdate();
     }
@@ -1004,6 +1005,31 @@ const EditorContent = ({
 
     return () => window.removeEventListener("message", handleEditorEvents);
   }, []);
+
+  const sendCanvasData = () => {
+    const shopstoryCanvasIframe = window.document.getElementById(
+      "shopstory-canvas"
+    ) as HTMLIFrameElement | undefined;
+
+    shopstoryCanvasIframe?.contentWindow?.postMessage(
+      {
+        type: "@easyblocks/canvas-data",
+        data: JSON.stringify({
+          compiled: renderableContent,
+          meta,
+          externalData,
+          formValues: form.values,
+          definitions: editorContext.definitions,
+          locale: editorContext.contextParams.locale,
+          locales: editorContext.locales,
+          isEditing,
+          devices: editorContext.devices,
+          focussedField,
+        }),
+      },
+      "*"
+    );
+  };
 
   const [isDataSaverOverlayOpen, setDataSaverOverlayOpen] = useState(false);
 

--- a/packages/editor/src/EditorChildWindow.tsx
+++ b/packages/editor/src/EditorChildWindow.tsx
@@ -15,10 +15,11 @@ import {
   TextEditor,
   configTraverse,
   itemMoved,
+  useEasyblocksCanvasContext,
 } from "@easyblocks/core/_internals";
 import { useForceRerender } from "@easyblocks/utils";
 import React, { useEffect, useRef, useState } from "react";
-import { z } from "zod";
+import { set, z } from "zod";
 import { CanvasRoot } from "./CanvasRoot/CanvasRoot";
 import EditableComponentBuilder from "./EditableComponentBuilder/EditableComponentBuilder.editor";
 import TypePlaceholder from "./Placeholder";
@@ -48,9 +49,6 @@ export function EasyblocksCanvas({
 }: {
   components?: Record<string, React.ComponentType<any>>;
 }) {
-  const { meta, compiled, externalData, editorContext } =
-    window.parent.editorWindowAPI;
-
   const [enabled, setEnabled] = useState(false);
   const activeDraggedEntryPath = useRef<string | null>(null);
   const { forceRerender } = useForceRerender();
@@ -68,26 +66,24 @@ export function EasyblocksCanvas({
     }
   }, []);
 
-  useEffect(() => {
-    window.parent.editorWindowAPI.onUpdate = () => {
-      // Force re-render when child gets info from parent that data changed
-      forceRerender();
-    };
-  });
+  const { meta, compiled, externalData, formValues, definitions } =
+    useEasyblocksCanvasContext();
 
-  const shouldNotRender = !enabled || !meta || !compiled || !externalData;
+  const shouldNotRender =
+    !enabled ||
+    !meta ||
+    !compiled ||
+    !externalData ||
+    !formValues ||
+    !definitions;
 
   if (shouldNotRender) {
     return <div>Loading...</div>;
   }
 
-  const sortableItems = getSortableItems(
-    editorContext.form.values,
-    editorContext
-  );
+  const sortableItems = getSortableItems(formValues, definitions);
 
   return (
-    /* EasyblocksMetadataProvider must be defined in case of nested <Easyblocks /> components are used! */
     <EasyblocksMetadataProvider meta={meta}>
       <CanvasRoot>
         <DndContext
@@ -98,7 +94,12 @@ export function EasyblocksCanvas({
             activeDraggedEntryPath.current = dragDataSchema.parse(
               event.active.data.current
             ).path;
-            window.parent.editorWindowAPI.editorContext.setFocussedField([]);
+            window.parent.postMessage({
+              type: "@easyblocks-editor/focus-field",
+              payload: {
+                target: [],
+              },
+            });
           }}
           onDragEnd={(event) => {
             document.documentElement.style.cursor = "";
@@ -109,9 +110,12 @@ export function EasyblocksCanvas({
 
               if (event.over.id === event.active.id) {
                 // If the dragged item is dropped on itself, we want to refocus the dragged item.
-                window.parent.editorWindowAPI.editorContext.setFocussedField(
-                  activeData.path
-                );
+                window.parent.postMessage({
+                  type: "@easyblocks-editor/focus-field",
+                  payload: {
+                    target: activeData.path,
+                  },
+                });
               } else {
                 const itemMovedEvent = itemMoved({
                   fromPath: activeData.path,
@@ -127,17 +131,23 @@ export function EasyblocksCanvas({
               }
             } else {
               // If there was no drop target, we want to refocus the dragged item.
-              window.parent.editorWindowAPI.editorContext.setFocussedField(
-                activeData.path
-              );
+              window.parent.postMessage({
+                type: "@easyblocks-editor/focus-field",
+                payload: {
+                  target: activeData.path,
+                },
+              });
             }
           }}
           onDragCancel={(event) => {
             document.documentElement.style.cursor = "";
             // If the drag was canceled, we want to refocus dragged item.
-            window.parent.editorWindowAPI.editorContext.setFocussedField(
-              dragDataSchema.parse(event.active.data.current).path
-            );
+            window.parent.postMessage({
+              type: "@easyblocks-editor/focus-field",
+              payload: {
+                target: dragDataSchema.parse(event.active.data.current).path,
+              },
+            });
           }}
         >
           <SortableContext items={sortableItems}>
@@ -162,15 +172,12 @@ export function EasyblocksCanvas({
   );
 }
 
-function getSortableItems(
-  rootNoCodeEntry: NoCodeComponentEntry,
-  editorContext: EditorContextType
-) {
+function getSortableItems(formValues: NoCodeComponentEntry, definitions: any) {
   const sortableItems: Array<string> = [];
 
   configTraverse(
-    rootNoCodeEntry,
-    editorContext,
+    formValues,
+    { definitions },
     ({ value, schemaProp, config }) => {
       if (schemaProp.type === "component-collection") {
         if (value.length === 0) {

--- a/packages/editor/src/EditorIframe.tsx
+++ b/packages/editor/src/EditorIframe.tsx
@@ -10,6 +10,7 @@ interface EditorIframeWrapperProps {
   height: number;
   transform: string;
   containerRef: React.RefObject<HTMLDivElement>;
+  onIframeLoaded?: () => void;
 }
 
 function EditorIframe({
@@ -19,11 +20,15 @@ function EditorIframe({
   height,
   transform,
   containerRef,
+  onIframeLoaded,
 }: EditorIframeWrapperProps) {
   const [isIframeReady, setIframeReady] = useState(false);
 
   const handleIframeLoaded = () => {
     setIframeReady(true);
+    if (onIframeLoaded) {
+      onIframeLoaded();
+    }
   };
 
   useWindowKeyDown("z", onEditorHistoryUndo, {

--- a/packages/editor/src/Placeholder.tsx
+++ b/packages/editor/src/Placeholder.tsx
@@ -1,7 +1,11 @@
 import { useDndContext } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { PlaceholderAppearance } from "@easyblocks/core";
-import { parsePath, useEasyblocksMetadata } from "@easyblocks/core/_internals";
+import {
+  parsePath,
+  useEasyblocksCanvasContext,
+  useEasyblocksMetadata,
+} from "@easyblocks/core/_internals";
 import { Colors, Fonts } from "@easyblocks/design-system";
 import { toArray } from "@easyblocks/utils";
 import React from "react";
@@ -117,13 +121,12 @@ type TypePlaceholderComponentBuilderProps = {
 export default function TypePlaceholder(
   props: TypePlaceholderComponentBuilderProps
 ) {
-  const { form } = window.parent.editorWindowAPI
-    .editorContext as EditorContextType;
+  const { formValues } = useEasyblocksCanvasContext();
   const meta = useEasyblocksMetadata();
   const dndContext = useDndContext();
 
   const draggedEntryPathParseResult = dndContext.active
-    ? parsePath(dndContext.active.data.current!.path, form)
+    ? parsePath(dndContext.active.data.current!.path, { values: formValues })
     : null;
 
   const draggedComponentDefinition = draggedEntryPathParseResult

--- a/packages/editor/src/useEditorGlobalKeyboardShortcuts.ts
+++ b/packages/editor/src/useEditorGlobalKeyboardShortcuts.ts
@@ -18,7 +18,10 @@ const GLOBAL_SHORTCUTS_KEYS = [
 
 const DATA_TRANSFER_FORMAT = "text/x-shopstory";
 
-function useEditorGlobalKeyboardShortcuts(editorContext: EditorContextType) {
+function useEditorGlobalKeyboardShortcuts(
+  editorContext: EditorContextType,
+  canvas: HTMLIFrameElement | undefined
+) {
   useEffect(() => {
     const { focussedField: focusedFields, actions } = editorContext;
 
@@ -101,11 +104,27 @@ function useEditorGlobalKeyboardShortcuts(editorContext: EditorContextType) {
     window.document.addEventListener("cut", handleCut);
     window.document.addEventListener("paste", handlePaste);
 
+    canvas?.contentWindow?.document?.addEventListener("keydown", handleKeydown);
+    canvas?.contentWindow?.document?.addEventListener("copy", handleCopy);
+    canvas?.contentWindow?.document?.addEventListener("cut", handleCut);
+    canvas?.contentWindow?.document?.addEventListener("paste", handlePaste);
+
     return () => {
       window.document.removeEventListener("keydown", handleKeydown);
       window.document.removeEventListener("copy", handleCopy);
       window.document.removeEventListener("cut", handleCut);
       window.document.removeEventListener("paste", handlePaste);
+
+      canvas?.contentWindow?.document?.removeEventListener(
+        "keydown",
+        handleKeydown
+      );
+      canvas?.contentWindow?.document?.removeEventListener("copy", handleCopy);
+      canvas?.contentWindow?.document?.removeEventListener("cut", handleCut);
+      canvas?.contentWindow?.document?.removeEventListener(
+        "paste",
+        handlePaste
+      );
     };
   });
 }


### PR DESCRIPTION
### Description
Removes editor context from Canvas element
Rewrite `window.parent` logic to `window.postmessage` on a `CanvasProvider`
This way the canvas can be hosted externally and it won't run into any CORS issues