### PR TITLE
feat(editor): include field in widgets

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -333,6 +333,7 @@ export type WidgetComponentProps<Identifier extends NonNullish = NonNullish> = {
   id: ExternalReference<Identifier>["id"];
   onChange: (newId: ExternalReference<Identifier>["id"]) => void;
   params?: Record<string, any>;
+  field: Field;
 };
 
 export type InlineTypeWidgetComponentProps<
@@ -341,6 +342,7 @@ export type InlineTypeWidgetComponentProps<
   value: Type;
   onChange: (newValue: Type) => void;
   params?: Record<string, any>;
+  field: Field;
 };
 
 export type TokenTypeWidgetComponentProps<

--- a/packages/editor/src/tinacms/fields/plugins/ExternalField/ExternalField.tsx
+++ b/packages/editor/src/tinacms/fields/plugins/ExternalField/ExternalField.tsx
@@ -130,6 +130,7 @@ const ExternalFieldComponent = (props: ExternalFieldProps) => {
                 }}
                 path={fieldNames[0]}
                 params={field.schemaProp.params}
+                field={field}
               />
             ) : (
               <MissingWidget type={field.schemaProp.type} />

--- a/packages/editor/src/tinacms/fields/plugins/LocalFIeld.tsx
+++ b/packages/editor/src/tinacms/fields/plugins/LocalFIeld.tsx
@@ -57,6 +57,7 @@ const LocalFieldPlugin = {
         params={
           "params" in field.schemaProp ? field.schemaProp.params : undefined
         }
+        field={field}
       />
     );
   }),

--- a/packages/editor/src/tinacms/fields/plugins/TokenField/TokenFieldPlugin.tsx
+++ b/packages/editor/src/tinacms/fields/plugins/TokenField/TokenFieldPlugin.tsx
@@ -254,6 +254,7 @@ function TokenFieldComponent<TokenValue extends NonNullish>({
           params={
             "params" in field.schemaProp ? field.schemaProp.params : undefined
           }
+          field={field}
         />
       ) : (
         <Input


### PR DESCRIPTION
### Description

To create fully custom widgets, include all the field parameters as a property. This enables the developer to read all the field information in a widget, so they can create fully custom widgets.

Example widget:

```
export default function NumberWidget({ value, onChange, field, params }) {
  return (
      <Field
        label={field.label}
        type="slider"
        unit={params.unit}
        numberInput={true}
        min={params.min}
        max={params.max}
        step={params.increment}
        size="small"
        onChange={(e, value) => {
          onChange(value);
        }}
        value={value}
        hint={field.description}
      />
  );
}
```