### PR TITLE
fix(canvas): dont prevent clicks on actions

### DIFF
--- a/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
+++ b/packages/editor/src/EditableComponentBuilder/BlockControls.tsx
@@ -139,10 +139,11 @@ export function BlocksControls({
 
   const focusOnBlock = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
-    event.preventDefault();
 
     if (isActive) {
       return;
+    } else {
+      event.preventDefault();
     }
 
     const closestEditableElementFromTarget = (


### PR DESCRIPTION
### Description
This small MR fixes the issue when clicking actions or links internally, that the event is not fired.