### PR TITLE
feat(editor): include groups definitions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import { ComponentType, ReactElement } from "react";
 import { PartialDeep } from "type-fest";
 import { Locale } from "./locales";
+import { InternalComponentDefinition } from "./_internals";
 
 export type ScalarOrCollection<T> = T | Array<T>;
 
@@ -438,6 +439,13 @@ export type RootParameter = {
   widgets: Array<Widget>;
 };
 
+export type GroupDefinition = {
+  key: string;
+  label: string;
+  collapsable?: boolean;
+  collapsed?: boolean;
+};
+
 export type NoCodeComponentDefinition<
   Values extends Record<string, any> = Record<string, any>,
   Params extends Record<string, any> = Record<string, any>
@@ -458,6 +466,7 @@ export type NoCodeComponentDefinition<
   }) => SidebarPreviewVariant | undefined;
   allowSave?: boolean;
   rootParams?: RootParameter[];
+  groups?: GroupDefinition[];
 };
 
 /**


### PR DESCRIPTION
### Description:

Adds more functionality to the schema `group` property.

#### Example usage:
```
  groups: [
    {
      key: "custom_group",
      label: "Custom group", // Custom label
      collapsable: true, // Set to true to make group collapsable
      collapsed: true, // Set to true to make group collapsed by default
    },
  ],
  schema: [
    {
      prop: "custom_group_prop",
      label: "Some custom group prop",
      type: "number",
      responsive: true,
      group: "custom_group", // Set group to custom group key
    },
```

This change adds collapse functionality, but still works with original `group: 'key'` behavior.