### PR TITLE
feat(editor): ability to use custom pickers

### DIFF
--- a/packages/editor/src/EasyblocksEditor.tsx
+++ b/packages/editor/src/EasyblocksEditor.tsx
@@ -62,6 +62,7 @@ export function EasyblocksEditor(props: EasyblocksEditorProps) {
           onExternalDataChange={props.onExternalDataChange ?? (() => ({}))}
           widgets={props.widgets}
           components={props.components}
+          pickers={props.pickers}
         />
       )}
 

--- a/packages/editor/src/EasyblocksEditorProps.ts
+++ b/packages/editor/src/EasyblocksEditorProps.ts
@@ -7,6 +7,7 @@ import {
   WidgetComponentProps,
 } from "@easyblocks/core";
 import React, { ComponentType } from "react";
+import { TemplatePicker } from "./TemplatePicker";
 
 export type ExternalDataChangeHandler = (
   externalData: RequestedExternalData,
@@ -23,6 +24,6 @@ export type EasyblocksEditorProps = {
     | ComponentType<WidgetComponentProps<any>>
     | ComponentType<InlineTypeWidgetComponentProps<any>>
   >;
-
+  pickers?: Record<string, TemplatePicker>;
   __debug?: boolean;
 };

--- a/packages/editor/src/EasyblocksParent.tsx
+++ b/packages/editor/src/EasyblocksParent.tsx
@@ -20,6 +20,9 @@ import { SpaceTokenWidget } from "./sidebar/SpaceTokenWidget";
 import { parseQueryParams } from "./parseQueryParams";
 import { DocumentDataWidgetComponent } from "./sidebar/DocumentDataWidget";
 import { ExternalDataChangeHandler } from "./EasyblocksEditorProps";
+import { TemplatePicker } from "./TemplatePicker";
+import { SectionPickerModal } from "./SectionPicker";
+import { SearchableSmallPickerModal } from "./SearchableSmallPickerModal";
 
 type EasyblocksParentProps = {
   config: Config;
@@ -31,6 +34,7 @@ type EasyblocksParentProps = {
     | ComponentType<InlineTypeWidgetComponentProps<any>>
   >;
   components?: Record<string, ComponentType<any>>;
+  pickers?: Record<string, TemplatePicker>;
 };
 
 const shouldForwardProp: ShouldForwardProp<"web"> = (propName, target) => {
@@ -46,6 +50,12 @@ const builtinWidgets: EasyblocksParentProps["widgets"] = {
   color: ColorTokenWidget,
   space: SpaceTokenWidget,
   "@easyblocks/document-data": DocumentDataWidgetComponent as any,
+};
+
+const builinPickers: EasyblocksParentProps["pickers"] = {
+  large: SectionPickerModal,
+  compact: SearchableSmallPickerModal,
+  "large-3": SectionPickerModal,
 };
 
 export function EasyblocksParent(props: EasyblocksParentProps) {
@@ -82,6 +92,10 @@ export function EasyblocksParent(props: EasyblocksParentProps) {
               ...props.widgets,
             }}
             components={props.components}
+            pickers={{
+              ...builinPickers,
+              ...props.pickers,
+            }}
           />
         </TooltipProvider>
         <Toaster containerStyle={{ zIndex: 100100 }} />

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -81,6 +81,7 @@ import { useEditorHistory } from "./useEditorHistory";
 import { checkLocalesCorrectness } from "./utils/locales/checkLocalesCorrectness";
 import { removeLocalizedFlag } from "./utils/locales/removeLocalizedFlag";
 import { ZodNullDef } from "zod";
+import { TemplatePicker } from "./TemplatePicker";
 
 const ContentContainer = styled.div`
   position: relative;
@@ -172,6 +173,7 @@ type EditorProps = {
     | ComponentType<TokenTypeWidgetComponentProps<any>>
   >;
   components?: Record<string, ComponentType<any>>;
+  pickers?: Record<string, TemplatePicker>;
 };
 
 export const Editor = EditorBackendInitializer;
@@ -1075,6 +1077,7 @@ const EditorContent = ({
                 <ModalPicker
                   onClose={closeComponentPickerModal}
                   config={componentPickerData.config}
+                  pickers={props.pickers}
                 />
               )}
             </SidebarAndContentContainer>

--- a/packages/editor/src/ModalPicker.tsx
+++ b/packages/editor/src/ModalPicker.tsx
@@ -13,16 +13,17 @@ import React, { FC } from "react";
 import { useEditorContext } from "./EditorContext";
 import { SearchableSmallPickerModal } from "./SearchableSmallPickerModal";
 import { SectionPickerModal } from "./SectionPicker";
-import { TemplatesDictionary } from "./TemplatePicker";
+import { TemplatePicker, TemplatesDictionary } from "./TemplatePicker";
 import { OpenComponentPickerConfig } from "./types";
 import { unrollAcceptsFieldIntoComponents } from "./unrollAcceptsFieldIntoComponents";
 
 type ModalProps = {
   config: OpenComponentPickerConfig;
   onClose: (config?: NoCodeComponentEntry) => void;
+  pickers?: Record<string, TemplatePicker>;
 };
 
-export const ModalPicker: FC<ModalProps> = ({ config, onClose }) => {
+export const ModalPicker: FC<ModalProps> = ({ config, onClose, pickers }) => {
   const editorContext = useEditorContext();
   const { form } = editorContext;
 
@@ -108,24 +109,14 @@ export const ModalPicker: FC<ModalProps> = ({ config, onClose }) => {
     }
   };
 
-  if (picker === "large" || picker === "large-3") {
-    return (
-      <SectionPickerModal
-        isOpen={true}
-        onClose={onModalClose}
-        templates={templatesDictionary}
-        mode={picker}
-      />
-    );
-  } else if (picker === "compact") {
-    return (
-      <SearchableSmallPickerModal
-        isOpen={true}
-        onClose={onModalClose}
-        templates={templatesDictionary}
-      />
-    );
-  } else {
-    throw new Error(`unknown template picker: "${picker}"`);
-  }
+  return pickers?.[picker] ? (
+    pickers[picker]({
+      isOpen: true,
+      onClose: onModalClose,
+      templates: templatesDictionary,
+      mode: picker,
+    })
+  ) : (
+    <div>Unknown picker: {picker}</div>
+  );
 };

--- a/packages/editor/src/SectionPicker.tsx
+++ b/packages/editor/src/SectionPicker.tsx
@@ -268,7 +268,7 @@ const GridRoot = styled.div`
   overflow-y: auto;
 `;
 
-export const SectionPickerModal: TemplatePicker<{ mode?: Mode }> = ({
+export const SectionPickerModal: TemplatePicker = ({
   isOpen,
   onClose,
   templates,

--- a/packages/editor/src/TemplatePicker.ts
+++ b/packages/editor/src/TemplatePicker.ts
@@ -11,6 +11,7 @@ type TemplatePickerProps = {
   isOpen: boolean;
   templates?: TemplatesDictionary;
   onClose: (template?: Template) => void;
+  mode?: string;
 };
 
 export type TemplatePicker<T = Record<never, never>> = React.FC<


### PR DESCRIPTION
### Description
This MR enables custom picker functionality. It mocks the `widgets` configuration, and comes with built-in pickers.
```
<EasyblocksEditor
  ...,
  pickers={{
    // Property key MUST match the id specified witin the picker type declaration
    small: SmallPicker
  }}
/>
```