### PR TITLE
Allow using refs on easyblock components 

### DIFF
--- a/packages/core/src/components/ComponentBuilder/ComponentBuilder.tsx
+++ b/packages/core/src/components/ComponentBuilder/ComponentBuilder.tsx
@@ -1,4 +1,10 @@
-import React, { ComponentType, Fragment, ReactElement } from "react";
+import React, {
+  ComponentType,
+  Fragment,
+  ReactElement,
+  Ref,
+  forwardRef,
+} from "react";
 import { findComponentDefinitionById } from "../../compiler/findComponentDefinition";
 import {
   isSchemaPropComponent,
@@ -319,7 +325,10 @@ export type InternalNoCodeComponentProps = NoCodeComponentProps & {
   };
 };
 
-function ComponentBuilder(props: ComponentBuilderProps): ReactElement | null {
+const ComponentBuilder = forwardRef(function ComponentBuilder(
+  props: ComponentBuilderProps,
+  ref: Ref<unknown>
+): ReactElement | null {
   const { compiled, passedProps, path, components, ...restProps } = props;
 
   const allPassedProps: Record<string, any> = {
@@ -431,7 +440,7 @@ function ComponentBuilder(props: ComponentBuilderProps): ReactElement | null {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { ref, __isSelected, ...restPassedProps } = allPassedProps || {};
+  const { __isSelected, ...restPassedProps } = allPassedProps || {};
 
   const runtime = {
     stitches: meta.stitches,
@@ -459,8 +468,8 @@ function ComponentBuilder(props: ComponentBuilderProps): ReactElement | null {
     __easyblocks: easyblocksProp,
   };
 
-  return <Component {...componentProps} />;
-}
+  return <Component {...componentProps} ref={ref} />;
+});
 
 function getComponent(
   componentDefinition: InternalComponentDefinition,

--- a/packages/editor/src/EditableComponentBuilder/EditableComponentBuilder.editor.tsx
+++ b/packages/editor/src/EditableComponentBuilder/EditableComponentBuilder.editor.tsx
@@ -2,7 +2,7 @@ import {
   ComponentBuilder,
   ComponentBuilderProps,
 } from "@easyblocks/core/_internals";
-import React from "react";
+import React, { Ref, forwardRef } from "react";
 import { BlocksControls } from "./BlockControls";
 
 type EditableComponentBuilderProps = ComponentBuilderProps & {
@@ -10,7 +10,10 @@ type EditableComponentBuilderProps = ComponentBuilderProps & {
   length: number;
 };
 
-function EditableComponentBuilder(props: EditableComponentBuilderProps) {
+const EditableComponentBuilder = forwardRef(function EditableComponentBuilder(
+  props: EditableComponentBuilderProps,
+  ref: Ref<unknown>
+) {
   const { path, compiled, index, length, components, ...restPassedProps } =
     props;
 
@@ -30,11 +33,12 @@ function EditableComponentBuilder(props: EditableComponentBuilderProps) {
         path={path}
         passedProps={restPassedProps}
         components={components}
+        ref={ref}
       />
     </BlocksControls>
   );
 
   return content;
-}
+});
 
 export default EditableComponentBuilder;


### PR DESCRIPTION
### This PR makes it possible to use `useRef` with child easyblock components.

Consider having 2 easyblock components: `MyForm` and `MyInput`. Suppose form component has to focus a child input when the button inside of the form is clicked.

This is commonly achieved through usage of `useRef/forwardRef`.

```tsx
const MyForm = ({ MyInput, ...props }: NoCodeComponentProps) => {
  const inputRef = useRef<HTMLInputElement>(null);
  return (
    <form>
      <MyInput.type {...MyInput.props} ref={inputRef}>
        {props.label}
      </MyInput.type>
      <Button onClick={() => inputRef.current?.focus()}>Focus</Button>
    </form>
  );
};
```
-----------------------------

However `MyInput.type` acrually refers to an internal easyblocks wrapper component `ComponentBuilder` which does not pass `ref` down the tree to the actual input component resolved in runtime.

To solve that, this PR wraps `ComponentBuilder` definition into `forwardRef` and passes `ref` down to the actual component implementation.